### PR TITLE
Fix getting `_stringLength_`, add missed `ReturnIfAbrupt`

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -33,12 +33,13 @@ When the _padRight_ method is called, the following steps are taken:
   1. ReturnIfAbrupt(_O_).
   1. Let _S_ be ToString(_O_).
   1. ReturnIfAbrupt(_S_).
-  1. Let _stringLength_ be ToLength(Get(_S_, *"length"*)).
-  1. ReturnIfAbrupt(_stringLength_).
+  1. Let _stringLength_ be the number of elements in S.
   1. If _fillString_ is *undefined*, let _fillStr_ be the empty String.
   1. Else, let _fillStr_ be ToString(_fillString_).
+  1. ReturnIfAbrupt(_fillStr_).
   1. If _fillStr_ is the empty String, let _fillStr_ be *" "* (a string consisting of a single space).
   1. Let _intMaxLength_ be ToLength(_maxLength_).
+  1. ReturnIfAbrupt(_intMaxLength_).
   1. If _intMaxLength_ is not greater than _stringLength_, return _S_.
   1. Let _fillLen_ be _intMaxLength_ - _stringLength_.
   1. Let _stringFiller_ be the empty String.


### PR DESCRIPTION
ES6 strings methods don't uses `Get` operation for getting `.length`, see, for example, [`String#slice`](http://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype.slice) or [String#includes](http://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype.includes) and `Get` called on string should throw error - [step 1](http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p).

Also, added missed `ReturnIfAbrupt`.
